### PR TITLE
Centralize screenshot capture utilities

### DIFF
--- a/games/pong/game.py
+++ b/games/pong/game.py
@@ -6,13 +6,12 @@ Pong Game for Toddlers
 A simple Pong game designed for toddlers with easy controls.
 
 Usage:
-  python game.py           # Normal game mode
-  python game.py --screenshot  # Generate thumbnail and exit
+  python game.py
 """
 
 import pygame
 import sys
-import argparse
+from utils import check_screenshot
 
 # Config
 WIDTH, HEIGHT = 1024, 600
@@ -25,18 +24,7 @@ BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
 BLUE = (0, 0, 255)
 
-def take_screenshot(screen):
-    """Take a screenshot and save as thumbnail"""
-    # Scale down to thumbnail size (320x240)
-    thumbnail_surface = pygame.transform.scale(screen, (320, 240))
-    
-    # Save thumbnail
-    import os
-    thumbnail_path = os.path.join(os.path.dirname(__file__), "thumbnail.png")
-    pygame.image.save(thumbnail_surface, thumbnail_path)
-    print(f"Thumbnail saved to {thumbnail_path}")
-
-def run_game(screenshot_mode=False):
+def run_game():
     """Main game function"""
     # Init pygame
     pygame.init()
@@ -58,28 +46,8 @@ def run_game(screenshot_mode=False):
     # Game loop
     clock = pygame.time.Clock()
     running = True
-    
+
     while running:
-        # In screenshot mode, just draw one frame and exit
-        if screenshot_mode:
-            # Draw everything
-            screen.fill(BLACK)
-            
-            # Draw paddles
-            pygame.draw.rect(screen, WHITE, (50, paddle1_y, PADDLE_WIDTH, PADDLE_HEIGHT))
-            pygame.draw.rect(screen, WHITE, (WIDTH - 50 - PADDLE_WIDTH, paddle2_y, PADDLE_WIDTH, PADDLE_HEIGHT))
-            
-            # Draw ball
-            pygame.draw.rect(screen, WHITE, (ball_x - BALL_SIZE//2, ball_y - BALL_SIZE//2, BALL_SIZE, BALL_SIZE))
-            
-            # Draw score
-            font = pygame.font.Font(None, 36)
-            score_text = font.render(f"Pong Game - {score1} : {score2}", True, BLUE)
-            screen.blit(score_text, (10, 10))
-            
-            pygame.display.flip()
-            take_screenshot(screen)
-            break
         
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -145,24 +113,14 @@ def run_game(screenshot_mode=False):
         screen.blit(score_text, (10, 10))
 
         pygame.display.flip()
+        check_screenshot(screen, os.path.join(os.path.dirname(__file__), "thumbnail.png"))
         clock.tick(FPS)
 
     pygame.quit()
 
 def main():
-    """Main entry point with command line argument support"""
-    parser = argparse.ArgumentParser(description='Pong Game for Toddlers')
-    parser.add_argument('--screenshot', action='store_true', 
-                       help='Generate thumbnail screenshot and exit')
-    
-    args = parser.parse_args()
-    
-    if args.screenshot:
-        print("Generating thumbnail...")
-        run_game(screenshot_mode=True)
-        print("Thumbnail generation complete!")
-    else:
-        run_game(screenshot_mode=False)
+    """Main entry point"""
+    run_game()
 
 if __name__ == "__main__":
     main() 

--- a/games/snake/game.py
+++ b/games/snake/game.py
@@ -11,15 +11,14 @@ A simple, forgiving Snake game designed for toddlers with:
 - Growing snake when eating food
 
 Usage:
-  python game.py           # Normal game mode
-  python game.py --screenshot  # Generate thumbnail and exit
+  python game.py
 """
 
 import pygame
 import sys
 import os
 import random
-import argparse
+from utils import screenshot_requested, check_screenshot
 
 # Config
 WIDTH, HEIGHT = 1024, 600
@@ -134,20 +133,11 @@ def move_snake(snake, food, direction_key, collision_sound, move_sound, eat_soun
         move_sound.play()  # Play tic sound for normal movement
         return True, food, 0
 
-def take_screenshot(screen):
-    """Take a screenshot and save as thumbnail"""
-    # Scale down to thumbnail size (320x240)
-    thumbnail_surface = pygame.transform.scale(screen, (320, 240))
-    
-    # Save thumbnail
-    thumbnail_path = os.path.join(os.path.dirname(__file__), "thumbnail.png")
-    pygame.image.save(thumbnail_surface, thumbnail_path)
-    print(f"Thumbnail saved to {thumbnail_path}")
-
-def run_game(screenshot_mode=False):
+def run_game():
     """Main game function"""
     # Init pygame
     pygame.init()
+    screenshot_mode = screenshot_requested()
     if not screenshot_mode:
         pygame.mixer.init()
 
@@ -181,30 +171,9 @@ def run_game(screenshot_mode=False):
     # Game loop
     clock = pygame.time.Clock()
     running = True
-    
+
     while running:
         current_time = pygame.time.get_ticks()
-        
-        # In screenshot mode, just draw one frame and exit
-        if screenshot_mode:
-            # Draw everything
-            screen.fill(BLACK)
-            
-            # Draw snake
-            for segment in snake:
-                pygame.draw.rect(screen, GREEN, (segment[0], segment[1], CELL_SIZE, CELL_SIZE))
-            
-            # Draw food
-            pygame.draw.rect(screen, RED, (food[0], food[1], CELL_SIZE, CELL_SIZE))
-            
-            # Draw score
-            font = pygame.font.Font(None, 36)
-            score_text = font.render(f"Snake Game - Score: {score}", True, BLUE)
-            screen.blit(score_text, (10, 10))
-            
-            pygame.display.flip()
-            take_screenshot(screen)
-            break
         
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -257,24 +226,14 @@ def run_game(screenshot_mode=False):
         screen.blit(score_text, (10, 10))
 
         pygame.display.flip()
+        check_screenshot(screen, os.path.join(os.path.dirname(__file__), "thumbnail.png"))
         clock.tick(FPS)
 
     pygame.quit()
 
 def main():
-    """Main entry point with command line argument support"""
-    parser = argparse.ArgumentParser(description='Snake Game for Toddlers')
-    parser.add_argument('--screenshot', action='store_true', 
-                       help='Generate thumbnail screenshot and exit')
-    
-    args = parser.parse_args()
-    
-    if args.screenshot:
-        print("Generating thumbnail...")
-        run_game(screenshot_mode=True)
-        print("Thumbnail generation complete!")
-    else:
-        run_game(screenshot_mode=False)
+    """Main entry point"""
+    run_game()
 
 if __name__ == "__main__":
     main() 

--- a/generate_thumbnails.py
+++ b/generate_thumbnails.py
@@ -7,11 +7,11 @@ Developer tool to generate thumbnails for all games in the games/ directory.
 Only regenerates thumbnails when game.py has been modified since last generation.
 
 Features:
-- Automatic game discovery in games/ directory
-- Caches file modification times to avoid unnecessary regeneration
-- Runs games in --screenshot mode to capture thumbnails
-- Generates 320x240 PNG thumbnails
-- Creates .thumbnail_cache.json to track generation status
+ - Automatic game discovery in games/ directory
+ - Caches file modification times to avoid unnecessary regeneration
+ - Launches games with SCREENSHOT_MODE=1 to capture thumbnails
+ - Generates 320x240 PNG thumbnails
+ - Creates .thumbnail_cache.json to track generation status
 
 Usage:
   python generate_thumbnails.py           # Generate all missing/outdated thumbnails
@@ -136,10 +136,12 @@ def generate_thumbnail(game_info):
     print(f"Generating thumbnail for {game_info['name']}...")
     
     try:
-        # Run game in screenshot mode
+        # Run game in screenshot mode using environment variable
+        env = os.environ.copy()
+        env["SCREENSHOT_MODE"] = "1"
         result = subprocess.run([
-            sys.executable, game_info['game_py'], '--screenshot'
-        ], cwd=os.getcwd(), capture_output=True, text=True, timeout=30)
+            sys.executable, game_info['game_py']
+        ], cwd=os.getcwd(), env=env, capture_output=True, text=True, timeout=30)
         
         if result.returncode == 0:
             if Path(game_info['thumbnail_path']).exists():
@@ -244,7 +246,7 @@ def main():
     
     if failed_count > 0:
         print(f"\n⚠️  {failed_count} games failed to generate thumbnails.")
-        print(f"Make sure each game supports the --screenshot argument.")
+        print("Make sure each game uses the screenshot utilities.")
 
 if __name__ == "__main__":
     main() 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pygame
+
+THUMBNAIL_SIZE = (320, 240)
+
+
+def screenshot_requested() -> bool:
+    """Return True if a screenshot should be taken."""
+    return "--screenshot" in sys.argv or os.environ.get("SCREENSHOT_MODE") == "1"
+
+
+def check_screenshot(screen: pygame.Surface, output_path: str) -> None:
+    """Save a scaled screenshot and exit if screenshot is requested."""
+    if not screenshot_requested():
+        return
+
+    thumbnail = pygame.transform.scale(screen, THUMBNAIL_SIZE)
+    pygame.image.save(thumbnail, output_path)
+    print(f"Thumbnail saved to {output_path}")
+    pygame.quit()
+    sys.exit(0)


### PR DESCRIPTION
## Summary
- add new `utils.py` with reusable screenshot helpers
- update `pong` and `snake` to use the new utilities
- simplify `generate_thumbnails.py` to enable screenshot mode via env var

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 generate_thumbnails.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68470dc35868833097ba1f6ad85555f5